### PR TITLE
Fixed title on homepage

### DIFF
--- a/build.js
+++ b/build.js
@@ -77,6 +77,7 @@ function makeIndexes(version)
             var data = dataArray.join("\n");
 
             var vars = extend({
+                guideTitle: "Node.js Manual",
                 title: title,
                 data: data,
                 whoAmI: version,

--- a/resources/landing/layout.jade
+++ b/resources/landing/layout.jade
@@ -4,7 +4,7 @@ mixin identifyBuild('','')
 
 mixin doctype
 
-mixin head()
+mixin head(guideTitle)
 
 body(onload="styleCode()")
 


### PR DESCRIPTION
The HTML was missing a title for the landing page. Fixed it to say "Node.js Manual"
