### PR TITLE
Remove header from layout, make build.js (more) Windows-friendly, and use consistent style in build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,156 +1,161 @@
-require("colors");
+require('colors');
 
-var argv = require("optimist").argv,
-    docs = require("./build/doc-build/docs"),
+var argv = require('optimist').argv,
+    docs = require('./build/doc-build/docs'),
     fs = require('fs'),
     md2html = require('marked'),
     jade = require('jade');
-    
+
 var version = argv._[0];
 var versions = [];
-var latest = "0.6.8";
+var latest = '0.6.8';
 
-//var outDir = "out/nodejs_dev_guide";
+console.log('GENERATING DOCUMENTATION'.green);
 
+var util = require('util'),
+    exec = require('child_process').exec;
 
-    console.log("GENERATING DOCUMENTATION".green);
-
-    var util = require('util'),
-        exec = require('child_process').exec,
-        child;
-
-    ls = exec('ls ./src/');
-    ls.stdout.on('data', function (data) {
-        if ("latest" == version)
+if ('latest' === version)
+{
+    versions.push('latest');
+}
+else if (/[\d]\.[\d]\.[\d]/.test(version))
+{
+    versions.push('v' + version);
+}
+else
+{
+    fs.readdir('./src', function (err, files) {
+        if (err)
         {
-            versions.push("latest");
+          return console.log(err);
         }
-        else if (/[\d]\.[\d]\.[\d]/.test(version))
-        {         
-            versions.push("v" + version);
-        }
-        else
-        {
-            data = data.replace(/^\.$/, "").replace(/index\.md/, "");
-
-            versions = data.split("\n");
-            versions = versions.filter(function (value) {
-                return (value === '') ? 0 : 1;
-            });
-        }  
-
+        versions = files.filter(function (value) {
+            return (value === 'index.md') ? 0 : 1;
+        });
         makeManualDocs(versions);
         makeJSRefDocs(versions);
-        makeNodeJSRefDocs(versions);        
+        makeNodeJSRefDocs(versions);
     });
+}
 
 function makeManualDocs(versions)
 {
-        versions.forEach(function (element, index, array)
-        {
-            var outDir = "out/" + element;
-            var tmpDir = "tmp/" + element;
+    versions.forEach(function (element, index, array)
+    {
+        var outDir = 'out/' + element;
+        var tmpDir = 'tmp/' + element;
 
-            docs.clean(tmpDir + "/nodejs_dev_guide");
-            docs.clean(outDir + "/nodejs_dev_guide");
+        docs.clean(tmpDir + '/nodejs_dev_guide');
+        docs.clean(outDir + '/nodejs_dev_guide');
 
-            docs.copyassets(outDir, "nodejs_dev_guide");
-            docs.generate(outDir + "/nodejs_dev_guide", process.cwd() + "/src/" + element + "/nodejs_dev_guide/", "nodejs_dev_guide");
+        docs.copyassets(outDir, 'nodejs_dev_guide');
+        docs.generate(outDir + '/nodejs_dev_guide', process.cwd() + '/src/' + element + '/nodejs_dev_guide/', 'nodejs_dev_guide');
 
-            makeIndexes(element);
-        });    
+        makeIndexes(element);
+    });
 }
 
 function makeIndexes(version)
 {
-        var jadeTemplateFile = "resources/landing/layout.jade";
-        var jadeTemplate = fs.readFileSync(jadeTemplateFile);
+    var jadeTemplateFile = 'resources/landing/layout.jade';
+    var jadeTemplate = fs.readFileSync(jadeTemplateFile);
 
-        var readContentStream = fs.createReadStream("src/index.md", {encoding: 'utf8'});
-    
-        readContentStream.on('data', function (data) {
-            var fn = jade.compile(jadeTemplate, {filename: jadeTemplateFile, pretty: false});
+    var readContentStream = fs.createReadStream('src/index.md', {encoding: 'utf8'});
 
-            var dataArray = data.split("\n");
+    readContentStream.on('data', function (data) {
+        var fn = jade.compile(jadeTemplate, {filename: jadeTemplateFile, pretty: false});
 
-            var title = "";
-            var data = dataArray.join("\n");
+        var dataArray = data.split('\n');
 
-            var vars = extend({
-                title: title,
-                data: data,
-                whoAmI: version,
-                markdown: markdown
-            });
+        var title = '';
+        var data = dataArray.join('\n');
 
-            var r = fn(vars);
-            
-            var writeStream = fs.createWriteStream("out/" + version + "/index.html", {flags: "w"});
-                    
-            writeStream.write(r);
-            });    
+        var vars = extend({
+            title: title,
+            data: data,
+            whoAmI: version,
+            markdown: markdown
+        });
+
+        var r = fn(vars);
+
+        var writeStream = fs.createWriteStream('out/' + version + '/index.html', {flags: 'w'});
+
+        writeStream.write(r);
+    });
 }
 
 function makeJSRefDocs(versions)
 {
-        versions.forEach(function (element, index, array)
-        {
-            exec('node ./build/ndoc/bin/ndoc --path=./src/' + element + '/js_doc -o ./out/' + element + '/js_doc/' + ' -t "Node.js Reference" --skin ./resources/nodejs_ref_guide/skins',
-                function (error, stdout, stderr) {
-                
-                console.log(stdout);
-                
-                if (error !== null) {
-                    var errMsg = 'exec error: ' + error;
-                    console.log(errMsg.red);
-                    process.exit(1);
-                }
-            });
-        });   
+    versions.forEach(function (element)
+    {
+        exec('node ./build/ndoc/bin/ndoc --path=./src/' + element + '/js_doc -o ./out/' + element + '/js_doc/' + ' -t "Node.js Reference" --skin ./resources/nodejs_ref_guide/skins',
+            function (error, stdout, stderr) {
+
+            console.log(stdout);
+
+            if (error !== null)
+            {
+                var errMsg = 'exec error: ' + error;
+                console.log(errMsg.red);
+                process.exit(1);
+            }
+        });
+    });
 }
 
 function makeNodeJSRefDocs(versions)
 {
-        versions.forEach(function (element, index, array)
-        {
-            exec('node ./build/ndoc/bin/ndoc --path=./src/' + element + '/nodejs_ref_guide -o ./out/' + element + '/nodejs_ref_guide/' + ' -t "Node.js Reference" --skin ./resources/nodejs_ref_guide/skins',
-                function (error, stdout, stderr) {
-                
+    versions.forEach(function (element, index)
+    {
+        exec('node ./build/ndoc/bin/ndoc --path=./src/' + element + '/nodejs_ref_guide -o ./out/' + element + '/nodejs_ref_guide/' + ' -t "Node.js Reference" --skin ./resources/nodejs_ref_guide/skins',
+            function (error, stdout, stderr)
+            {
                 console.log(stdout);
-                
-                if (error !== null) {
+
+                if (error !== null)
+                {
                     var errMsg = 'exec error: ' + error;
                     console.log(errMsg.red);
                     process.exit(1);
                 }
 
-                if (index == array.length - 1)
+                if (index === versions.length - 1)
                 {
-                    console.log("All Done!".green);
+                    console.log('All Done!'.green);
                     process.exit(0);
                 }
-            });
-        }); 
+            }
+        );
+    });
 }
 
-function markdown(text) {
+function markdown(text)
+{
     return md2html(text);
 }
 
-function extend(o, plus) {
-  var r = {}, i;
-  for (i in o) {
-    if (o.hasOwnProperty(i)) {
-      r[i] = o[i];
+function extend(o, plus)
+{
+    var r = {}, i;
+    for (i in o)
+    {
+        if (o.hasOwnProperty(i))
+        {
+            r[i] = o[i];
+        }
     }
-  }
-  if (plus) {
-    for (i in plus) {
-      if (plus.hasOwnProperty(i)) {
-        r[i] = plus[i];
-      }
+    if (plus)
+    {
+        for (i in plus)
+        {
+            if (plus.hasOwnProperty(i))
+            {
+                r[i] = plus[i];
+            }
+        }
     }
-  }
 
-  return r;
+    return r;
 }

--- a/resources/common_layout.jade
+++ b/resources/common_layout.jade
@@ -69,19 +69,6 @@ mixin topBar(fullPath)
           form(id='searchbox', action='', class='pull-right')  
             input(class='span3', name='query', type='text', placeholder="Search Documentation", title="Search across all the documentation types") 
 
-mixin header
-  header.jumbotron.masthead#overview
-    //- a(class="c9-sponsor", href="http://c9.io/", title="cloud9 ide", target="_blank")
-    div.inner
-      div.container
-        if nodejsRef == 'true'
-          h1 Node.js API Reference
-        else if jsDoc == 'true'
-          h1 Javascript Reference
-        else
-          h1 Node.js Guide
-        p.lead
-
 mixin footer
   footer#footer
         .container

--- a/resources/landing/layout.jade
+++ b/resources/landing/layout.jade
@@ -10,9 +10,7 @@ body(onload="styleCode()")
 
   mixin topBar(whoAmI)
 
-  mixin header
-
-  .container
+  .container.shift
     .content
       .row.container
         .span5.offset4.sidebarContainer

--- a/resources/nodejs_dev_guide/layout.jade
+++ b/resources/nodejs_dev_guide/layout.jade
@@ -10,9 +10,7 @@ body(onload="styleCode()")
 
   mixin topBar(whoAmI)
 
-  mixin header
-
-  .container
+  .container.shift
     .content
       .row.container
         .span5.offset4.sidebarContainer

--- a/resources/nodejs_ref_guide/skins/skeleton/csses/refguide_overrides.css
+++ b/resources/nodejs_ref_guide/skins/skeleton/csses/refguide_overrides.css
@@ -147,26 +147,6 @@ a.brand {
     cursor: pointer;
 }
 
-.masthead {
-    background: #55a500 url(../images/header-back.jpg) repeat-x 0 bottom;
-}
-.masthead .container {
-    width: 680px;
-    padding-left: 285px;
-    margin: 0 auto;
-}
-.jumbotron {
-    min-width: 1000px;
-    padding-top: 40px;
-    position: relative;
-}
-
-.jumbotron .inner {
-/*    background: transparent url(../images/header-back.png) top center;*/
-    padding: 45px 0;
-/*    -webkit-box-shadow: inset 0 10px 30px rgba(0,0,0,.3);
-    -moz-box-shadow: inset 0 10px 30px rgba(0,0,0,.3);*/
-}
 .c9-sponsor {
     background: url(../images/c9-sponsor.png) no-repeat 0 0;
     z-index: 1;
@@ -176,18 +156,6 @@ a.brand {
     top: 55px;
     right: 0;
     outline: none;
-}
-.jumbotron h1 {
-    font-size: 54px;
-    line-height: 1;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, .5);
-}
-
-.jumbotron h1, .jumbotron p {
-    margin-bottom: 9px;
-    color: white;
-/*    text-align: center;*/
-    text-shadow: 0 1px 1px rgba(0, 0, 0, .3);
 }
 
 /*
@@ -519,6 +487,10 @@ ul.tabs .double ul, ul.tabs .triple ul, ul.tabs .quad ul{
 /*
   Center content (the "real stuff")
 */
+
+.shift {
+    margin-top: 40px;
+}
 
 .content .container {
     background: url(../images/sidebar-border.png) repeat-y 95px 0;

--- a/resources/nodejs_ref_guide/skins/templates/layout.jade
+++ b/resources/nodejs_ref_guide/skins/templates/layout.jade
@@ -14,9 +14,7 @@ body(onload="styleCode()")
 
   mixin topBar(tree.children[0].href)
 
-  mixin header
-
-  .container
+  .container.shift
     .content
       .row.container
         .span5.offset4.sidebarContainer


### PR DESCRIPTION
It should be noted that building the docs still fails on Windows, but at least we can now read the versions from src/ correctly now.
