### PR TITLE
The String.concat part markdown miss code

### DIFF
--- a/src/0.8.14/js_doc/String.markdown
+++ b/src/0.8.14/js_doc/String.markdown
@@ -457,7 +457,7 @@ This method combines the text from one or more strings and returns a new string.
 The following example combines strings into a new string.
     
 	var hello = "Hello, ";
- console.log(hello.concat("Kevin", " have a nice day.")); /// Hello, Kevin have a nice day.
+    console.log(hello.concat("Kevin", " have a nice day.")); /// Hello, Kevin have a nice day.
    
 
 


### PR DESCRIPTION
http://nodemanual.org/latest/js_doc/String.html#String.concat
The line should be in code quote too.

> console.log(hello.concat("Kevin", " have a nice day.")); /// Hello, Kevin have a nice day.

Previously, the passage is 

```
var hello = "Hello, ";
```

 console.log(hello.concat("Kevin", " have a nice day.")); /// Hello, Kevin have a nice day.

Now, the passage is 

```
var hello = "Hello, ";
console.log(hello.concat("Kevin", " have a nice day.")); /// Hello, Kevin have a nice day.
```

Although It is small mistake, but I hope it can be fixed soon. :construction:
:smile:
